### PR TITLE
fix: retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -184,10 +184,13 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -195,10 +198,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -217,6 +225,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -338,6 +347,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -526,6 +546,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1043,6 +1072,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1487,7 +1517,7 @@ dependencies = [
  "quote",
  "strum",
  "syn",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2187,20 +2217,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -2209,7 +2225,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -2219,7 +2235,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2234,8 +2250,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
- "reqwest",
+ "opentelemetry",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -2245,13 +2261,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest",
- "thiserror 2.0.18",
+ "reqwest 0.12.28",
+ "thiserror",
  "tokio",
  "tonic 0.14.5",
  "tracing",
@@ -2263,8 +2279,8 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.14.3",
  "tonic 0.14.5",
  "tonic-prost",
@@ -2283,23 +2299,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
 dependencies = [
  "chrono",
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.30.0",
- "percent-encoding",
- "rand",
- "thiserror 2.0.18",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -2311,10 +2312,10 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
- "rand",
- "thiserror 2.0.18",
+ "rand 0.9.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -2349,6 +2350,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "base64",
  "clap",
  "clap_complete",
@@ -2358,35 +2360,37 @@ dependencies = [
  "futures",
  "glob",
  "http",
+ "httpdate",
  "itertools",
  "log",
  "maplit",
  "mime",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "pact_consumer",
  "pact_models",
  "pretty_assertions",
  "regex",
- "reqwest",
+ "reqwest 0.13.1",
  "reqwest-middleware",
+ "reqwest-retry",
  "reqwest-tracing",
  "serde",
  "serde_json",
  "serde_with",
  "test-log",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-core",
  "tracing-log",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "trycmd",
  "url",
@@ -2419,7 +2423,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -2492,9 +2496,9 @@ dependencies = [
  "onig",
  "pact-plugin-driver",
  "pact_models",
- "rand",
+ "rand 0.9.2",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -2532,7 +2536,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2568,11 +2572,11 @@ dependencies = [
  "nom 7.1.3",
  "onig",
  "parse-zoneinfo",
- "rand",
+ "rand 0.9.2",
  "rand_regex",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -2877,7 +2881,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2892,13 +2896,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2940,7 +2944,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2950,7 +2965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2963,12 +2978,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_regex"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04db2e382d13679a1e42400e90e306cdbb79dc5cd41bb035ba4eae72e78cdf37"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "regex-syntax",
 ]
 
@@ -3088,11 +3109,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3104,7 +3123,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3118,36 +3136,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.4.2"
+name = "reqwest"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest",
- "serde",
- "thiserror 1.0.69",
+ "reqwest 0.13.1",
+ "thiserror",
  "tower-service",
 ]
 
 [[package]]
-name = "reqwest-tracing"
-version = "0.5.8"
+name = "reqwest-retry"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest 0.13.1",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5af0cd6fc3d3c8f703d597af70b6e4e62432c63157b49419fa1ffaf481702"
 dependencies = [
  "anyhow",
  "async-trait",
  "getrandom 0.2.17",
  "http",
  "matchit",
- "opentelemetry 0.30.0",
- "reqwest",
+ "opentelemetry",
+ "reqwest 0.13.1",
  "reqwest-middleware",
  "tracing",
- "tracing-opentelemetry 0.31.0",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3379,6 +3466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,7 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3457,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3747,31 +3845,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4157,7 +4235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -4196,30 +4274,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
-dependencies = [
- "js-sys",
- "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "web-time",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -4538,6 +4598,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5130,7 +5204,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "xz2",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,9 @@ uuid = { version = "1.21.0", features = ["v4"] }
 # OpenTelemetry dependencies
 async-trait = "0.1.89"
 http = "1.4.0"
-reqwest-middleware = "0.4.2"
-reqwest-tracing = { version = "0.5.8", features = ["tracing-opentelemetry_0_31_pkg", "opentelemetry_0_30"] }
+reqwest-middleware = "0.5"
+reqwest-retry = "0.9"
+reqwest-tracing = { version = "0.7.0", features = ["opentelemetry_0_31"] }
 opentelemetry = "0.31.0"
 opentelemetry-http = "0.31.0"
 opentelemetry_sdk = "0.31.0"
@@ -62,10 +63,12 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter","registry", 
 tracing-opentelemetry = "0.32.1"
 
 
+httpdate = "1.0"
+
 [dependencies.reqwest]
-version = "0.12.28"
+version = "0.13"
 default-features = false
-features = ["rustls-tls-native-roots","native-tls-vendored", "blocking", "json", "stream"]
+features = ["rustls-native-certs", "native-tls-vendored", "blocking", "json", "stream"]
 [dependencies.serde_with]
 version = "3.17.0"
 features = ["json"]
@@ -77,6 +80,11 @@ trycmd = "1.0.0"
 pact_consumer = "~1.4.2"
 test-log = { version = "0.2.15", features = ["trace"] }
 pretty_assertions = "1.4.0"
+axum = "0.8"
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["net", "macros", "rt-multi-thread"]
 
 [profile.release]
 strip = true      # Automatically strip symbols from the binary.

--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,17 @@ create_or_update_github_webhook:
 
 test_github_webhook:
 	@curl -v -X POST ${PACT_BROKER_BASE_URL}/webhooks/${GITHUB_WEBHOOK_UUID}/execute -H "Authorization: Bearer ${PACT_BROKER_TOKEN}"
+
+## ========================
+## README maintenance tasks
+## ========================
+
+# Refresh all ```console help blocks in README.md.
+# Uses TRYCMD=overwrite so the README exactly matches what the snapshot tests expect.
+update_readme_help:
+	TRYCMD=overwrite cargo test cli_tests
+
+# Check that README.md is up to date with the current binary's --help output.
+# Runs the snapshot tests; exits non-zero if any block would change. Useful in CI.
+check_readme_help:
+	cargo test cli_tests

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Options:
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
 
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present.
+          
+          [env: PACT_BROKER_HTTP_RETRIES=]
+          [default: 8]
+
       --validate
           Validate the Pact files before publishing.
 
@@ -294,6 +300,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -354,6 +362,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -438,6 +448,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -498,6 +510,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -548,6 +562,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -596,6 +612,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -644,6 +662,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -702,6 +722,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -771,6 +793,12 @@ Options:
 
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present.
+          
+          [env: PACT_BROKER_HTTP_RETRIES=]
+          [default: 8]
 
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file
@@ -866,6 +894,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -920,6 +950,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -1071,6 +1103,12 @@ Options:
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
 
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present.
+          
+          [env: PACT_BROKER_HTTP_RETRIES=]
+          [default: 8]
+
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file
           
@@ -1184,6 +1222,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -a, --pacticipant <PACTICIPANT>
           The pacticipant name. Use once for each pacticipant being checked. The following options (--version, --latest, --tag, --branch) must come after each --pacticipant.
   -e, --version <VERSION>
@@ -1259,6 +1299,12 @@ Options:
 
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present.
+          
+          [env: PACT_BROKER_HTTP_RETRIES=]
+          [default: 8]
 
   -r, --provider <PROVIDER>
           The name of the provider
@@ -1365,6 +1411,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
       --name <NAME>
           Pacticipant name
       --display-name <DISPLAY_NAME>
@@ -1421,6 +1469,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
       --name <NAME>
           Pacticipant name
   -o, --output <OUTPUT>
@@ -1471,6 +1521,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -o, --output <OUTPUT>
           Value must be one of ["json", "table"] [default: table] [possible values: json, table]
   -c, --ssl-certificate <SSL_CERT_FILE>
@@ -1556,6 +1608,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -1610,6 +1664,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
       --uuid <UUID>
           Specify the uuid for the webhook
   -X, --request <METHOD>
@@ -1698,6 +1754,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -1746,6 +1804,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -c, --ssl-certificate <SSL_CERT_FILE>
           The path to a valid SSL certificate file [env: SSL_CERT_FILE=]
       --skip-ssl-verification
@@ -1794,6 +1854,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
       --branch <BRANCH>
           The pacticipant branch name
   -a, --pacticipant <PACTICIPANT>
@@ -1848,6 +1910,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -a, --pacticipant <PACTICIPANT>
           The pacticipant name
   -e, --version <VERSION>
@@ -1904,6 +1968,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -a, --pacticipant <PACTICIPANT>
           The pacticipant name
   -e, --version <VERSION>
@@ -1958,6 +2024,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -a, --pacticipant <PACTICIPANT>
           The name of the pacticipant that the version belongs to
   -e, --version <VERSION>
@@ -2018,6 +2086,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
   -a, --pacticipant <PACTICIPANT>
           The pacticipant name
   -e, --version <VERSION>
@@ -2111,6 +2181,8 @@ Options:
           Pact Broker bearer token [env: PACT_BROKER_TOKEN=]
       --custom-header <HEADER>
           Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)
+      --retries <PACT_BROKER_HTTP_RETRIES>
+          The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present. [env: PACT_BROKER_HTTP_RETRIES=] [default: 8]
       --provider <PROVIDER>
           The provider name
   -a, --provider-app-version <PROVIDER_APP_VERSION>

--- a/src/cli/pact_broker/main.rs
+++ b/src/cli/pact_broker/main.rs
@@ -43,7 +43,6 @@ pub mod utils;
 pub mod verification;
 pub mod versions;
 pub mod webhooks;
-use utils::with_retries;
 // for otel
 use crate::cli::utils::{CYAN, GREEN, RED, YELLOW};
 use http::Extensions;
@@ -54,6 +53,7 @@ use reqwest::Request;
 use reqwest::Response;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_middleware::{Middleware, Next};
+use reqwest_retry::{DefaultRetryableStrategy, Retryable, RetryableStrategy};
 use reqwest_tracing::TracingMiddleware;
 
 use crate::cli::pact_broker::main::types::SslOptions;
@@ -303,6 +303,120 @@ impl Middleware for OtelPropagatorMiddleware {
     }
 }
 
+/// Parses the value of a `Retry-After` response header into a [`Duration`].
+///
+/// The header may be either:
+/// - an integer number of seconds (`Retry-After: 120`), or
+/// - an HTTP-date (`Retry-After: Fri, 31 Dec 1999 23:59:59 GMT`).
+///
+/// For a date in the past the returned duration is [`Duration::ZERO`].
+/// Returns `None` if the header is absent or unparseable.
+///
+/// # Arguments
+///
+/// * `response` - The HTTP response to inspect.
+///
+/// # Returns
+///
+/// The wait duration indicated by the header, or `None` if absent/unparseable.
+fn parse_retry_after(response: &Response) -> Option<std::time::Duration> {
+    let header_value = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?;
+
+    // Try the decimal-seconds form first (e.g. "120").
+    if let Ok(secs) = header_value.trim().parse::<u64>() {
+        return Some(std::time::Duration::from_secs(secs));
+    }
+
+    // Fall back to the HTTP-date form (e.g. "Fri, 31 Dec 1999 23:59:59 GMT").
+    if let Ok(system_time) = httpdate::parse_http_date(header_value) {
+        let delay = system_time
+            .duration_since(std::time::SystemTime::now())
+            .unwrap_or_default();
+        return Some(delay);
+    }
+
+    None
+}
+
+/// Middleware that retries transient HTTP failures and honours `Retry-After` headers.
+///
+/// Uses [`DefaultRetryableStrategy`] to classify responses: 5xx, 408, and 429 are
+/// treated as transient and retried.
+///
+/// For `429 Too Many Requests` responses the `Retry-After` header is read when
+/// present; both the decimal-seconds form (`Retry-After: 120`) and the HTTP-date
+/// form (`Retry-After: Fri, 31 Dec 1999 23:59:59 GMT`) are supported.  The parsed
+/// delay is passed to [`utils::compute_retry_delay`], which adds a ≈20 % jitter
+/// (capped at 60 s) to spread simultaneous retries across the new rate-limit window.
+///
+/// All other transient failures use exponential back-off (`10^attempt` ms).
+///
+/// Requests with streaming bodies that cannot be cloned produce an error on the first
+/// transient failure without retrying.
+struct RetryMiddleware {
+    /// Maximum number of total attempts, including the initial send.  `0` means
+    /// one attempt with no retries (same as `1`).
+    max_attempts: u8,
+}
+
+#[async_trait::async_trait]
+impl Middleware for RetryMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        let max_retries = self.max_attempts.saturating_sub(1) as u32;
+        let mut n_past_retries: u32 = 0;
+
+        loop {
+            // Clone the request so we still hold it for subsequent retry iterations.
+            let cloned = req.try_clone().ok_or_else(|| {
+                reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "Request object is not cloneable. Are you passing a streaming body?"
+                ))
+            })?;
+
+            let result = next.clone().run(cloned, extensions).await;
+
+            // Classify the response using reqwest-retry's built-in strategy.
+            if let Some(Retryable::Transient) = DefaultRetryableStrategy.handle(&result) {
+                if n_past_retries < max_retries {
+                    let delay = if let Ok(ref resp) = result {
+                        utils::compute_retry_delay(
+                            resp.status(),
+                            parse_retry_after(resp),
+                            n_past_retries + 1,
+                        )
+                    } else {
+                        utils::compute_retry_delay(
+                            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                            None,
+                            n_past_retries + 1,
+                        )
+                    };
+                    trace!(
+                        attempt = n_past_retries + 1,
+                        max_attempts = self.max_attempts,
+                        delay_ms = delay.as_millis(),
+                        "retrying transient HTTP failure"
+                    );
+                    tokio::time::sleep(delay).await;
+                    n_past_retries += 1;
+                    continue;
+                }
+            }
+
+            break result;
+        }
+    }
+}
+
 pub trait WithCurrentSpan {
     fn with_current_span<F, R>(&self, f: F) -> R
     where
@@ -498,14 +612,12 @@ impl HALClient {
         // Apply custom headers if present
         request_builder = self.apply_custom_headers(request_builder);
 
-        let response = utils::with_retries(self.retries, request_builder)
-            .await
-            .map_err(|err| {
-                PactBrokerError::IoError(format!(
-                    "Failed to access pact broker path '{}' - {}. URL: '{}'",
-                    &path, err, &self.url,
-                ))
-            })?;
+        let response = request_builder.send().await.map_err(|err| {
+            PactBrokerError::IoError(format!(
+                "Failed to access pact broker path '{}' - {}. URL: '{}'",
+                &path, err, &self.url,
+            ))
+        })?;
 
         self.parse_broker_response(path.to_string(), response).await
     }
@@ -566,14 +678,12 @@ impl HALClient {
         }
         .header("Accept", "application/hal+json");
 
-        let response = utils::with_retries(self.retries, request_builder)
-            .await
-            .map_err(|err| {
-                PactBrokerError::IoError(format!(
-                    "Failed to delete pact broker path '{}' - {}. URL: '{}'",
-                    &path, err, &self.url,
-                ))
-            })?;
+        let response = request_builder.send().await.map_err(|err| {
+            PactBrokerError::IoError(format!(
+                "Failed to delete pact broker path '{}' - {}. URL: '{}'",
+                &path, err, &self.url,
+            ))
+        })?;
 
         self.parse_broker_response(path.to_string(), response).await
     }
@@ -800,8 +910,7 @@ impl HALClient {
         } else {
             request_builder.header("Content-Type", "application/json")
         };
-        let response = with_retries(self.retries, request_builder).await;
-        match response {
+        match request_builder.send().await {
             Ok(res) => {
                 self.parse_broker_response(url.path().to_string(), res)
                     .await
@@ -878,7 +987,24 @@ fn handle_validation_errors(body: Value) -> PactBrokerError {
 }
 
 impl HALClient {
-    pub fn setup(url: &str, auth: Option<HttpAuth>, ssl_options: SslOptions) -> HALClient {
+    /// Builds the reqwest-middleware client stack for a given retry count and SSL
+    /// configuration.
+    ///
+    /// The middleware chain is (outermost → innermost):
+    /// 1. [`TracingMiddleware`] — adds OpenTelemetry trace context to every request.
+    /// 2. [`OtelPropagatorMiddleware`] — injects baggage / W3C trace propagation headers.
+    /// 3. [`RetryMiddleware`] — retries transient 5xx / 408 / 429 failures, honouring
+    ///    any `Retry-After` header present on the response.
+    ///
+    /// # Arguments
+    ///
+    /// * `retries` - Maximum number of total attempts (including the first send).
+    /// * `ssl_options` - TLS configuration (custom CA cert, skip-verify, …).
+    ///
+    /// # Returns
+    ///
+    /// A fully configured [`ClientWithMiddleware`] ready for use.
+    fn build_middleware_client(retries: u8, ssl_options: &SslOptions) -> ClientWithMiddleware {
         let mut builder = reqwest::Client::builder().user_agent(format!(
             "{}/{}",
             env!("CARGO_PKG_NAME"),
@@ -888,10 +1014,23 @@ impl HALClient {
         debug!("Using ssl_options: {:?}", ssl_options);
         if let Some(ref path) = ssl_options.ssl_cert_path {
             if let Ok(cert_bytes) = std::fs::read(path) {
-                if let Ok(cert) = reqwest::Certificate::from_pem_bundle(&cert_bytes) {
-                    debug!("Adding SSL certificate from path: {}", path);
-                    for c in cert {
-                        builder = builder.add_root_certificate(c.clone());
+                match reqwest::Certificate::from_pem_bundle(&cert_bytes) {
+                    Ok(certs) => {
+                        debug!("Adding SSL certificate from path: {}", path);
+                        if ssl_options.use_root_trust_store {
+                            // Merge custom cert into the native root store.
+                            builder = builder.tls_certs_merge(certs);
+                        } else {
+                            // Use ONLY the provided certificate; bypass all built-in roots.
+                            debug!("Disabling root trust store for SSL — using only the provided certificate");
+                            builder = builder.tls_certs_only(certs);
+                        }
+                    }
+                    Err(err) => {
+                        debug!(
+                            "Could not parse SSL certificate from path {}: {}",
+                            path, err
+                        );
                     }
                 }
             } else {
@@ -900,21 +1039,29 @@ impl HALClient {
                     path
                 );
             }
+        } else if !ssl_options.use_root_trust_store {
+            debug!("ssl-trust-store disabled but no custom certificate provided; proceeding with system roots");
         }
         if ssl_options.skip_ssl {
             builder = builder.danger_accept_invalid_certs(true);
             debug!("Skipping SSL certificate validation");
         }
-        if !ssl_options.use_root_trust_store {
-            builder = builder.tls_built_in_root_certs(false);
-            debug!("Disabling root trust store for SSL");
-        }
 
-        let built_client = builder.build().unwrap();
-        let client = ClientBuilder::new(built_client)
+        let built_client = builder.build().expect("failed to build reqwest client");
+        ClientBuilder::new(built_client)
             .with(TracingMiddleware::default())
             .with(OtelPropagatorMiddleware)
-            .build();
+            .with(RetryMiddleware { max_attempts: retries })
+            .build()
+    }
+
+    pub fn setup(url: &str, auth: Option<HttpAuth>, ssl_options: SslOptions) -> HALClient {
+        let retries = std::env::var("PACT_BROKER_HTTP_RETRIES")
+            .ok()
+            .and_then(|v| v.parse::<u8>().ok())
+            .unwrap_or(8);
+
+        let client = Self::build_middleware_client(retries, &ssl_options);
 
         HALClient {
             client,
@@ -922,9 +1069,20 @@ impl HALClient {
             path_info: None,
             auth,
             custom_headers: None,
-            retries: 3,
+            retries,
             ssl_options,
         }
+    }
+
+    /// Sets the number of HTTP request retry attempts, overriding the default (3) or any
+    /// value read from the `PACT_BROKER_HTTP_RETRIES` environment variable.
+    ///
+    /// CLI command handlers call this after construction to apply the `--retries` flag value.
+    /// This rebuilds the internal HTTP client so the new retry count takes effect immediately.
+    pub fn with_retry_count(mut self, retries: u8) -> Self {
+        self.retries = retries;
+        self.client = Self::build_middleware_client(retries, &self.ssl_options);
+        self
     }
 }
 
@@ -1735,4 +1893,257 @@ mod tests
     let result = client.navigate("next", &hashmap!{}).await.unwrap();
     expect!(result.path_info).to(be_some().value(serde_json::Value::String("Yay! You found your way here".to_string())));
   }
+}
+
+// MARK: RetryMiddleware integration tests
+
+#[cfg(test)]
+mod retry_middleware_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::{Router, body::Body, http::StatusCode, response::Response, routing::get};
+    use tokio::net::TcpListener;
+
+    use super::{HALClient, SslOptions};
+
+    async fn spawn_test_server(router: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{}", addr)
+    }
+
+    fn hal_client(base_url: &str, retries: u8) -> HALClient {
+        HALClient::with_url(base_url, None, SslOptions::default(), None)
+            .with_retry_count(retries)
+    }
+
+    #[tokio::test]
+    async fn retries_on_429_too_many_requests() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    if n < 2 {
+                        Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    } else {
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/hal+json")
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    }
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 3);
+        let result = client.fetch("").await;
+
+        assert!(result.is_ok(), "expected OK but got: {:?}", result.err());
+        assert_eq!(request_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_404_not_found() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    StatusCode::NOT_FOUND
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 3);
+        let _ = client.fetch("").await;
+
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            1,
+            "404 should not be retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_on_500_internal_server_error() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    } else {
+                        StatusCode::OK
+                    }
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 3);
+        let _ = client.fetch("").await;
+
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "500 should be retried once"
+        );
+    }
+
+    #[tokio::test]
+    async fn honours_integer_retry_after_header() {
+        // Retry-After: 0 exercises the header path without real delay.
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            .header("Retry-After", "0")
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    } else {
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/hal+json")
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    }
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 3);
+        let result = client.fetch("").await;
+
+        assert!(result.is_ok());
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn honours_http_date_retry_after_header() {
+        // An HTTP-date Retry-After in the past should result in a zero delay,
+        // confirming that the date form is parsed rather than silently ignored.
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            // A date well in the past → delay is immediately 0.
+                            .header("Retry-After", "Thu, 01 Jan 1970 00:00:00 GMT")
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    } else {
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/hal+json")
+                            .body(Body::from("{\"_links\":{}}"))
+                            .unwrap()
+                    }
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 3);
+        let result = client.fetch("").await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            2,
+            "HTTP-date Retry-After should be parsed and retry should happen"
+        );
+    }
+
+    #[tokio::test]
+    async fn sends_one_request_when_retries_is_zero() {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = request_count.clone();
+
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let count = count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Response::builder()
+                        .status(StatusCode::TOO_MANY_REQUESTS)
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 0);
+        let _ = client.fetch("").await;
+
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            1,
+            "retries=0 should send exactly one request"
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_last_failure_when_all_retries_exhausted() {
+        let router = Router::new().route(
+            "/",
+            get(|| async {
+                Response::builder()
+                    .status(StatusCode::TOO_MANY_REQUESTS)
+                    .body(Body::empty())
+                    .unwrap()
+            }),
+        );
+
+        let base_url = spawn_test_server(router).await;
+        let client = hal_client(&base_url, 2);
+        let result = client.fetch("").await;
+
+        assert!(
+            result.is_err(),
+            "all retries exhausted should return error, got: {:?}",
+            result
+        );
+    }
 }

--- a/src/cli/pact_broker/main/branches/delete_branch.rs
+++ b/src/cli/pact_broker/main/branches/delete_branch.rs
@@ -4,7 +4,7 @@ use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
     utils::{
         delete_templated_broker_relation, get_auth, get_broker_relation, get_broker_url,
-        get_custom_headers, get_ssl_options,
+        get_custom_headers, get_retries, get_ssl_options,
     },
 };
 
@@ -28,7 +28,8 @@ pub fn delete_branch(args: &clap::ArgMatches) -> Result<String, PactBrokerError>
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let pb_branch_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:pacticipant-branch".to_string(),

--- a/src/cli/pact_broker/main/can_i_deploy.rs
+++ b/src/cli/pact_broker/main/can_i_deploy.rs
@@ -14,7 +14,7 @@ where
 use crate::cli::{
     pact_broker::main::{
         HALClient, Notice, PactBrokerError, process_notices,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -248,7 +248,8 @@ pub fn can_i_deploy(
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         // Build matrix_href_path using selectors
         let mut matrix_href_path = String::from("/matrix?");

--- a/src/cli/pact_broker/main/deployments/record_deployment.rs
+++ b/src/cli/pact_broker/main/deployments/record_deployment.rs
@@ -4,7 +4,7 @@ use serde_json::{Value, json};
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -19,7 +19,8 @@ pub fn record_deployment(args: &clap::ArgMatches) -> Result<String, PactBrokerEr
     let custom_headers = get_custom_headers(args);
     let ssl_options = get_ssl_options(args);
     tokio::runtime::Runtime::new().unwrap().block_on(async {
-                let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone());
+                let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone())
+                    .with_retry_count(get_retries(args));
 
                 let res = hal_client.clone()
                     .fetch(

--- a/src/cli/pact_broker/main/deployments/record_release.rs
+++ b/src/cli/pact_broker/main/deployments/record_release.rs
@@ -4,7 +4,7 @@ use serde_json::{Value, json};
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -25,7 +25,8 @@ pub fn record_release(args: &clap::ArgMatches) -> Result<String, PactBrokerError
     let custom_headers = get_custom_headers(args);
     let ssl_options = get_ssl_options(args);
     tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone());
+            let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone())
+                .with_retry_count(get_retries(args));
             // todo add trim_end_matches to broker url arg parse
             let res = hal_client.clone()
                 .fetch(

--- a/src/cli/pact_broker/main/deployments/record_support_ended.rs
+++ b/src/cli/pact_broker/main/deployments/record_support_ended.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -34,7 +34,8 @@ pub fn record_support_ended(args: &clap::ArgMatches) -> Result<String, PactBroke
     let ssl_options = get_ssl_options(args);
 
     tokio::runtime::Runtime::new().unwrap().block_on(async {
-                let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone());
+                let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone())
+                    .with_retry_count(get_retries(args));
 
 
                 let res = hal_client.clone()

--- a/src/cli/pact_broker/main/deployments/record_undeployment.rs
+++ b/src/cli/pact_broker/main/deployments/record_undeployment.rs
@@ -5,7 +5,7 @@ use crate::cli::{
         HALClient, PactBrokerError,
         utils::{
             follow_broker_relation, get_auth, get_broker_relation, get_broker_url,
-            get_custom_headers, get_ssl_options,
+            get_custom_headers, get_retries, get_ssl_options,
         },
     },
     utils,
@@ -37,7 +37,8 @@ pub fn record_undeployment(args: &clap::ArgMatches) -> Result<String, PactBroker
     let ssl_options = get_ssl_options(args);
 
     tokio::runtime::Runtime::new().unwrap().block_on(async {
-        let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone());
+        let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()),ssl_options.clone(), custom_headers.clone())
+            .with_retry_count(get_retries(args));
 
             #[derive(Debug, serde::Deserialize)]
             struct Environment {

--- a/src/cli/pact_broker/main/environments/create.rs
+++ b/src/cli/pact_broker/main/environments/create.rs
@@ -4,7 +4,7 @@ use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
         utils::{
-            get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_ssl_options,
+            get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_retries, get_ssl_options,
         },
     },
     utils,
@@ -27,7 +27,8 @@ pub fn create_environment(args: &clap::ArgMatches) -> Result<String, PactBrokerE
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let pb_environments_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:environments".to_string(),

--- a/src/cli/pact_broker/main/environments/delete.rs
+++ b/src/cli/pact_broker/main/environments/delete.rs
@@ -1,7 +1,7 @@
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -18,7 +18,8 @@ pub fn delete_environment(args: &clap::ArgMatches) -> Result<String, PactBrokerE
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let res = hal_client
             .clone()
             .fetch(&(broker_url.clone() + "/environments/" + &uuid))

--- a/src/cli/pact_broker/main/environments/describe.rs
+++ b/src/cli/pact_broker/main/environments/describe.rs
@@ -1,7 +1,7 @@
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -19,7 +19,8 @@ pub fn describe_environment(args: &clap::ArgMatches) -> Result<String, PactBroke
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let res = hal_client
             .fetch(&(broker_url + "/environments/" + &uuid))
             .await;

--- a/src/cli/pact_broker/main/environments/list.rs
+++ b/src/cli/pact_broker/main/environments/list.rs
@@ -3,7 +3,7 @@ use crate::cli::{
         HALClient, PactBrokerError,
         utils::{
             follow_broker_relation, get_auth, get_broker_relation, get_broker_url,
-            get_custom_headers, get_ssl_options,
+            get_custom_headers, get_retries, get_ssl_options,
         },
     },
     utils,
@@ -22,7 +22,8 @@ pub fn list_environments(args: &clap::ArgMatches) -> Result<String, PactBrokerEr
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let pb_environments_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:environments".to_string(),

--- a/src/cli/pact_broker/main/environments/update.rs
+++ b/src/cli/pact_broker/main/environments/update.rs
@@ -1,7 +1,7 @@
 use crate::cli::{
     pact_broker::main::{
         HALClient, PactBrokerError,
-        utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+        utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
     },
     utils,
 };
@@ -27,7 +27,8 @@ pub fn update_environment(args: &clap::ArgMatches) -> Result<String, PactBrokerE
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         // check if the uuid url exists, if not return an error, otherwise continue
 

--- a/src/cli/pact_broker/main/pact_publish.rs
+++ b/src/cli/pact_broker/main/pact_publish.rs
@@ -19,7 +19,7 @@ use serde_json::{Value, json};
 use crate::cli::pact_broker::main::utils::{
     get_auth, get_broker_relation, get_broker_url, get_custom_headers,
 };
-use crate::cli::pact_broker::main::utils::{get_ssl_options, handle_error};
+use crate::cli::pact_broker::main::utils::{get_retries, get_ssl_options, handle_error};
 use crate::cli::pact_broker::main::{HALClient, Notice, process_notices};
 use crate::cli::utils::git_info;
 use std::collections::HashMap;
@@ -274,7 +274,8 @@ pub fn publish_pacts(args: &ArgMatches) -> Result<Value, i32> {
         Some(auth.clone()),
         ssl_options.clone(),
         custom_headers.clone(),
-    );
+    )
+    .with_retry_count(get_retries(args));
 
     let publish_pact_href_path = tokio::runtime::Runtime::new().unwrap().block_on(async {
         get_broker_relation(

--- a/src/cli/pact_broker/main/pacticipants/create.rs
+++ b/src/cli/pact_broker/main/pacticipants/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::pact_broker::main::{
     HALClient, Link, PactBrokerError,
-    utils::{get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_ssl_options},
+    utils::{get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
 };
 use maplit::hashmap;
 use std::result::Result::Ok;
@@ -22,7 +22,8 @@ pub fn create_or_update_pacticipant(args: &clap::ArgMatches) -> Result<String, P
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         let template_values = hashmap! {
             "pacticipant".to_string() => pacticipant_name.to_string(),

--- a/src/cli/pact_broker/main/pacticipants/describe.rs
+++ b/src/cli/pact_broker/main/pacticipants/describe.rs
@@ -27,7 +27,8 @@ pub fn describe_pacticipant(
             auth.clone(),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(broker_details.retries);
         let pb_pacticipant_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:pacticipant".to_string(),
@@ -224,6 +225,7 @@ mod describe_pacticipant_tests {
             auth: None,
             ssl_options: Default::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         let result = describe_pacticipant(
@@ -289,6 +291,7 @@ mod describe_pacticipant_tests {
             auth: None,
             ssl_options: Default::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         let result = describe_pacticipant(

--- a/src/cli/pact_broker/main/pacticipants/list.rs
+++ b/src/cli/pact_broker/main/pacticipants/list.rs
@@ -25,7 +25,8 @@ pub fn list_pacticipants(
             auth.clone(),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(broker_details.retries);
         let pb_pacticipants_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:pacticipants".to_string(),
@@ -196,6 +197,7 @@ mod list_pacticipants_tests {
             auth: None,
             ssl_options: Default::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         let result = list_pacticipants(&broker_details, OutputType::Json);

--- a/src/cli/pact_broker/main/pacts/get_pacts.rs
+++ b/src/cli/pact_broker/main/pacts/get_pacts.rs
@@ -26,7 +26,8 @@ pub fn get_pacts(
             broker_details.auth.clone(),
             broker_details.ssl_options.clone(),
             broker_details.custom_headers.clone(),
-        );
+        )
+        .with_retry_count(broker_details.retries);
 
         // Build the appropriate HAL relation and template parameters
         let (relation, path) = build_pacts_path(provider, consumer, branch, latest);
@@ -409,6 +410,7 @@ mod get_pacts_tests {
             auth: None,
             ssl_options: SslOptions::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         // act
@@ -531,6 +533,7 @@ mod get_pacts_tests {
             auth: None,
             ssl_options: SslOptions::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         // act
@@ -619,6 +622,7 @@ mod get_pacts_tests {
             auth: None,
             ssl_options: SslOptions::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         // act

--- a/src/cli/pact_broker/main/pacts/list_latest_pact_versions.rs
+++ b/src/cli/pact_broker/main/pacts/list_latest_pact_versions.rs
@@ -23,7 +23,8 @@ pub fn list_latest_pact_versions(
             auth.clone(),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(broker_details.retries);
         let pb_latest_pact_versions_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:latest-pact-versions".to_string(),
@@ -189,6 +190,7 @@ mod lists_latest_pact_versions_tests {
             auth: None,
             ssl_options: SslOptions::default(),
             custom_headers: None,
+            retries: 0,
         };
 
         // act

--- a/src/cli/pact_broker/main/provider_states/list.rs
+++ b/src/cli/pact_broker/main/provider_states/list.rs
@@ -46,7 +46,8 @@ pub fn list_provider_states(
             broker_details.auth.clone(),
             broker_details.ssl_options.clone(),
             broker_details.custom_headers.clone(),
-        );
+        )
+        .with_retry_count(broker_details.retries);
 
         // Build the path based on provided parameters
         let path = build_provider_states_path(provider, branch, environment);

--- a/src/cli/pact_broker/main/subcommands.rs
+++ b/src/cli/pact_broker/main/subcommands.rs
@@ -39,6 +39,14 @@ pub fn add_broker_auth_arguments() -> Vec<Arg> {
             .action(clap::ArgAction::Append)
             .help("Custom header(s) to send with requests (format: 'Header-Name: Value', can be used multiple times)")
             .value_name("HEADER"),
+        Arg::new("retries")
+            .long("retries")
+            .num_args(1)
+            .default_value("8")
+            .value_parser(clap::value_parser!(u8))
+            .help("The number of times to retry failed HTTP requests to the Pact Broker (retries on 5xx, 408, and 429). Delays use exponential back-off starting at 500 ms and doubling each attempt (0.5 s, 1 s, 2 s, 4 s, 8 s, …). 429 responses honour the Retry-After header when present.")
+            .value_name("PACT_BROKER_HTTP_RETRIES")
+            .env("PACT_BROKER_HTTP_RETRIES"),
     ]
 }
 pub fn add_publish_pacts_subcommand() -> Command {

--- a/src/cli/pact_broker/main/tags/create_version_tag.rs
+++ b/src/cli/pact_broker/main/tags/create_version_tag.rs
@@ -1,6 +1,6 @@
 use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
-    utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+    utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
 };
 
 pub fn create_version_tag(args: &clap::ArgMatches) -> Result<String, PactBrokerError> {
@@ -20,7 +20,8 @@ pub fn create_version_tag(args: &clap::ArgMatches) -> Result<String, PactBrokerE
     let tag_with_git_branch = args.get_flag("tag-with-git-branch");
     // ensure version exists if auto-create is not set
     let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone());
+            let hal_client: HALClient = HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone())
+                .with_retry_count(get_retries(args));
             let version_href = format!("{}/pacticipants/{}/versions/{}", broker_url, pacticipant_name, version_number);
             let version_exists = hal_client.fetch(&version_href).await.is_ok();
             if !auto_create_version {
@@ -44,7 +45,8 @@ pub fn create_version_tag(args: &clap::ArgMatches) -> Result<String, PactBrokerE
                     Some(auth.clone()),
                     ssl_options.clone(),
                     custom_headers.clone(),
-                );
+                )
+                .with_retry_count(get_retries(args));
                 for tag in tags {
                     print!(
                         "Tagging version '{}' of pacticipant '{}' with tag '{}'",

--- a/src/cli/pact_broker/main/tags/delete_tag.rs
+++ b/src/cli/pact_broker/main/tags/delete_tag.rs
@@ -2,7 +2,7 @@ use maplit::hashmap;
 
 use crate::cli::pact_broker::main::{
     HALClient, Link, PactBrokerError,
-    utils::{get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_ssl_options},
+    utils::{get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
 };
 
 pub fn delete_version_tag(args: &clap::ArgMatches) -> Result<String, PactBrokerError> {
@@ -21,7 +21,8 @@ pub fn delete_version_tag(args: &clap::ArgMatches) -> Result<String, PactBrokerE
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         // First, get the pacticipant to access its version-tag relation
         let pb_pacticipant_href_path = get_broker_relation(

--- a/src/cli/pact_broker/main/types.rs
+++ b/src/cli/pact_broker/main/types.rs
@@ -10,6 +10,7 @@ pub struct BrokerDetails {
     pub(crate) url: String,
     pub(crate) ssl_options: SslOptions,
     pub(crate) custom_headers: Option<CustomHeaders>,
+    pub(crate) retries: u8,
 }
 
 impl BrokerDetails {
@@ -17,19 +18,21 @@ impl BrokerDetails {
         args: &clap::ArgMatches,
     ) -> Result<Self, crate::cli::pact_broker::main::PactBrokerError> {
         use crate::cli::pact_broker::main::utils::{
-            get_auth, get_broker_url, get_custom_headers, get_ssl_options,
+            get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options,
         };
 
         let url = get_broker_url(args).trim_end_matches('/').to_string();
         let auth = get_auth(args);
         let custom_headers = get_custom_headers(args);
         let ssl_options = get_ssl_options(args);
+        let retries = get_retries(args);
 
         Ok(BrokerDetails {
             auth: Some(auth),
             url,
             ssl_options,
             custom_headers,
+            retries,
         })
     }
 }

--- a/src/cli/pact_broker/main/utils.rs
+++ b/src/cli/pact_broker/main/utils.rs
@@ -4,97 +4,50 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use comfy_table::{Table, presets::UTF8_FULL};
-use futures::StreamExt;
 use maplit::hashmap;
 use pact_models::http_utils::HttpAuth;
-use reqwest_middleware::RequestBuilder;
+use reqwest::StatusCode;
 use serde_json::Value;
-use tokio::time::sleep;
-use tracing::{trace, warn};
 
-use crate::{cli::pact_broker::main::types::SslOptions, dbg_as_curl};
+use crate::cli::pact_broker::main::types::SslOptions;
 
 use super::{CustomHeaders, HALClient, Link, PactBrokerError};
 
-/// Retries a request on failure
-pub(crate) async fn with_retries(
-    retries: u8,
-    request: RequestBuilder,
-) -> Result<reqwest::Response, reqwest_middleware::Error> {
-    match &request.try_clone() {
-        None => {
-            warn!("with_retries: Could not retry the request as it is not cloneable");
-            request.send().await
+/// Computes how long to wait before the next retry attempt.
+///
+/// For `429 Too Many Requests` responses the server may include a `Retry-After`
+/// header.  When the parsed delay is present, the delay is that value plus up to
+/// 20 % extra, capped so the additional buffer never exceeds 60 seconds.  This
+/// spreads retries out across the new rate-limit window instead of hammering the
+/// server the instant it opens.
+///
+/// For all other retryable status codes (and for 429 without a `Retry-After`
+/// header) exponential back-off is used: `500 × 2^(attempt − 1)` milliseconds,
+/// giving 500 ms, 1 s, 2 s, 4 s, 8 s, … on successive retries.
+///
+/// # Arguments
+///
+/// * `status` - The HTTP status code of the failed response.
+/// * `retry_after` - Duration parsed from the `Retry-After` header, if present.
+///   Supports both the integer-seconds form and the HTTP-date form.
+/// * `attempt` - The current attempt number (1-based), used for exponential back-off.
+///
+/// # Returns
+///
+/// The [`Duration`] to sleep before the next attempt.
+pub(crate) fn compute_retry_delay(
+    status: StatusCode,
+    retry_after: Option<Duration>,
+    attempt: u32,
+) -> Duration {
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        if let Some(base) = retry_after {
+            let secs = base.as_secs();
+            let extra = (secs / 5).min(60); // ≈ 20 % of secs, capped at 60 s
+            return Duration::from_secs(secs + extra);
         }
-        Some(rb) => futures::stream::iter((1..=retries).step_by(1))
-            .fold(
-                (
-                    None::<Result<reqwest::Response, reqwest_middleware::Error>>,
-                    rb.try_clone(),
-                ),
-                |(response, request), attempt| async move {
-                    match request {
-                        Some(request_builder) => match response {
-                            None => {
-                                let next = request_builder.try_clone();
-                                (Some(dbg_as_curl!(request_builder).send().await), next)
-                            }
-                            Some(response) => {
-                                trace!(
-                                    "with_retries: attempt {}/{} is {:?}",
-                                    attempt, retries, response
-                                );
-                                match response {
-                                    Ok(ref res) => {
-                                        if res.status().is_server_error() {
-                                            match request_builder.try_clone() {
-                                                None => (Some(response), None),
-                                                Some(rb) => {
-                                                    sleep(Duration::from_millis(
-                                                        10_u64.pow(attempt as u32),
-                                                    ))
-                                                    .await;
-                                                    (Some(request_builder.send().await), Some(rb))
-                                                }
-                                            }
-                                        } else {
-                                            (Some(response), None)
-                                        }
-                                    }
-                                    Err(ref err) => {
-                                        if err.is_status() {
-                                            if err.status().unwrap_or_default().is_server_error() {
-                                                match request_builder.try_clone() {
-                                                    None => (Some(response), None),
-                                                    Some(rb) => {
-                                                        sleep(Duration::from_millis(
-                                                            10_u64.pow(attempt as u32),
-                                                        ))
-                                                        .await;
-                                                        (
-                                                            Some(request_builder.send().await),
-                                                            Some(rb),
-                                                        )
-                                                    }
-                                                }
-                                            } else {
-                                                (Some(response), None)
-                                            }
-                                        } else {
-                                            (Some(response), None)
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        None => (response, None),
-                    }
-                },
-            )
-            .await
-            .0
-            .unwrap(),
     }
+    Duration::from_millis(500 * 2_u64.pow(attempt.saturating_sub(1)))
 }
 
 // pub(crate) fn as_safe_ref(
@@ -134,6 +87,14 @@ pub(crate) fn get_broker_url(args: &clap::ArgMatches) -> String {
     args.get_one::<String>("broker-base-url")
         .expect("url is required")
         .to_string()
+}
+
+/// Reads the `--retries` / `PACT_BROKER_HTTP_RETRIES` value from parsed CLI arguments.
+///
+/// Falls back to `8` if the argument is absent (which should not happen in practice
+/// because the flag carries a `default_value`).
+pub(crate) fn get_retries(args: &clap::ArgMatches) -> u8 {
+    args.get_one::<u8>("retries").copied().unwrap_or(8)
 }
 pub(crate) fn get_ssl_options(args: &clap::ArgMatches) -> SslOptions {
     SslOptions {
@@ -207,6 +168,94 @@ pub(crate) fn get_custom_headers(args: &clap::ArgMatches) -> Option<CustomHeader
     }
 
     None
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use std::time::Duration;
+
+    use reqwest::StatusCode;
+
+    use super::compute_retry_delay;
+
+    // MARK: compute_retry_delay unit tests
+
+    #[test]
+    fn delay_for_429_without_retry_after_uses_exponential_backoff() {
+        // attempt=2: 500 * 2^(2-1) = 1000 ms
+        let delay = compute_retry_delay(StatusCode::TOO_MANY_REQUESTS, None, 2);
+        assert_eq!(delay, Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn delay_for_5xx_uses_exponential_backoff() {
+        // attempt=3: 500 * 2^(3-1) = 2000 ms
+        let delay = compute_retry_delay(StatusCode::INTERNAL_SERVER_ERROR, None, 3);
+        assert_eq!(delay, Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn delay_starts_at_500ms_on_first_attempt() {
+        // attempt=1: 500 * 2^0 = 500 ms
+        let delay = compute_retry_delay(StatusCode::INTERNAL_SERVER_ERROR, None, 1);
+        assert_eq!(delay, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn delay_for_429_with_retry_after_applies_1_2x_multiplier() {
+        // Retry-After: 10 s → 10 + min(10/5, 60) = 10 + 2 = 12
+        let delay = compute_retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::from_secs(10)),
+            1,
+        );
+        assert_eq!(delay, Duration::from_secs(12));
+    }
+
+    #[test]
+    fn delay_for_429_with_large_retry_after_caps_extra_at_60_seconds() {
+        // Retry-After: 400 s → 400 + min(80, 60) = 460
+        let delay = compute_retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::from_secs(400)),
+            1,
+        );
+        assert_eq!(delay, Duration::from_secs(460));
+    }
+
+    #[test]
+    fn delay_for_429_with_retry_after_at_cap_boundary() {
+        // Retry-After: 300 s → 300 + min(60, 60) = 360
+        let delay = compute_retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::from_secs(300)),
+            1,
+        );
+        assert_eq!(delay, Duration::from_secs(360));
+    }
+
+    #[test]
+    fn delay_for_5xx_ignores_retry_after_value() {
+        // Retry-After is irrelevant for non-429 status codes.
+        let delay_with = compute_retry_delay(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Some(Duration::from_secs(999)),
+            2,
+        );
+        let delay_without = compute_retry_delay(StatusCode::INTERNAL_SERVER_ERROR, None, 2);
+        assert_eq!(delay_with, delay_without);
+    }
+
+    #[test]
+    fn delay_for_429_with_zero_retry_after_adds_no_extra() {
+        // Retry-After: 0 s → 0 + min(0, 60) = 0
+        let delay = compute_retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::ZERO),
+            1,
+        );
+        assert_eq!(delay, Duration::from_secs(0));
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/pact_broker/main/versions/create.rs
+++ b/src/cli/pact_broker/main/versions/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
-    utils::{get_auth, get_broker_url, get_custom_headers, get_ssl_options},
+    utils::{get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options},
 };
 
 pub fn create_or_update_version(args: &clap::ArgMatches) -> Result<String, PactBrokerError> {
@@ -24,7 +24,8 @@ pub fn create_or_update_version(args: &clap::ArgMatches) -> Result<String, PactB
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let version_href = format!(
             "{}/pacticipants/{}/versions/{}",
             broker_url, pacticipant_name, version_number

--- a/src/cli/pact_broker/main/versions/describe.rs
+++ b/src/cli/pact_broker/main/versions/describe.rs
@@ -8,7 +8,7 @@ use crate::cli::pact_broker::main::{
     types::{OutputType, SslOptions},
     utils::{
         follow_broker_relation, follow_templated_broker_relation, get_auth, get_broker_relation,
-        get_broker_url, get_custom_headers, get_ssl_options,
+        get_broker_url, get_custom_headers, get_retries, get_ssl_options,
     },
 };
 
@@ -36,6 +36,7 @@ pub fn describe_version(args: &clap::ArgMatches) -> Result<String, PactBrokerErr
             &auth,
             &custom_headers,
             &ssl_options,
+            get_retries(args),
             pacticipant_name,
             env_name,
             deployed_only,
@@ -56,7 +57,8 @@ pub fn describe_version(args: &clap::ArgMatches) -> Result<String, PactBrokerErr
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
         let pb_version_href_path =
             get_broker_relation(hal_client.clone(), pb_relation_href, broker_url.to_string()).await;
 
@@ -130,6 +132,7 @@ fn describe_version_by_environment(
     auth: &HttpAuth,
     custom_headers: &Option<crate::cli::pact_broker::main::CustomHeaders>,
     ssl_options: &SslOptions,
+    retries: u8,
     pacticipant_name: &str,
     environment_name: &str,
     deployed_only: bool,
@@ -142,7 +145,8 @@ fn describe_version_by_environment(
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(retries);
 
         // First, get the environment UUID
         let environments_href = get_broker_relation(

--- a/src/cli/pact_broker/main/webhooks/create.rs
+++ b/src/cli/pact_broker/main/webhooks/create.rs
@@ -4,7 +4,7 @@ use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
     utils::{
         follow_templated_broker_relation, get_auth, get_broker_relation, get_broker_url,
-        get_custom_headers, get_ssl_options,
+        get_custom_headers, get_retries, get_ssl_options,
     },
 };
 
@@ -58,7 +58,8 @@ pub fn create_webhook(args: &clap::ArgMatches) -> Result<String, PactBrokerError
 
     let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
         let hal_client: HALClient =
-            HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone());
+            HALClient::with_url(&broker_url, Some(auth.clone()), ssl_options.clone(), custom_headers.clone())
+            .with_retry_count(get_retries(args));
       let pb_webhook_href_path = get_broker_relation(
             hal_client.clone(),
             "pb:webhook".to_string(),

--- a/src/cli/pact_broker/main/webhooks/delete.rs
+++ b/src/cli/pact_broker/main/webhooks/delete.rs
@@ -4,7 +4,7 @@ use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
     utils::{
         follow_templated_broker_relation, get_auth, get_broker_relation, get_broker_url,
-        get_custom_headers, get_ssl_options,
+        get_custom_headers, get_retries, get_ssl_options,
     },
 };
 
@@ -25,7 +25,8 @@ pub fn delete_webhook(args: &clap::ArgMatches) -> Result<String, PactBrokerError
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         // Get the pb:webhook relation from the index
         let pb_webhook_href_path = get_broker_relation(

--- a/src/cli/pact_broker/main/webhooks/test.rs
+++ b/src/cli/pact_broker/main/webhooks/test.rs
@@ -4,7 +4,7 @@ use crate::cli::pact_broker::main::{
     HALClient, PactBrokerError,
     utils::{
         follow_templated_broker_relation, get_auth, get_broker_relation, get_broker_url,
-        get_custom_headers, get_ssl_options,
+        get_custom_headers, get_retries, get_ssl_options,
     },
 };
 
@@ -21,7 +21,8 @@ pub fn test_webhook(args: &clap::ArgMatches) -> Result<String, PactBrokerError> 
             Some(auth.clone()),
             ssl_options.clone(),
             custom_headers.clone(),
-        );
+        )
+        .with_retry_count(get_retries(args));
 
         let pb_webhook_href_path = get_broker_relation(
             hal_client.clone(),

--- a/src/cli/pact_broker_client.rs
+++ b/src/cli/pact_broker_client.rs
@@ -31,7 +31,7 @@ use crate::cli::pact_broker::main::tags::create_version_tag;
 use crate::cli::pact_broker::main::tags::delete_tag::delete_version_tag;
 use crate::cli::pact_broker::main::types::{BrokerDetails, OutputType};
 use crate::cli::pact_broker::main::utils::{
-    get_auth, get_broker_url, get_custom_headers, get_ssl_options, handle_error,
+    get_auth, get_broker_url, get_custom_headers, get_retries, get_ssl_options, handle_error,
 };
 use crate::cli::pact_broker::main::versions::create::create_or_update_version;
 use crate::cli::pact_broker::main::versions::describe::describe_version;
@@ -106,6 +106,7 @@ pub fn run(args: &ArgMatches, raw_args: Vec<String>) -> Result<serde_json::Value
                 auth: Some(auth),
                 ssl_options: ssl_options.clone(),
                 custom_headers: custom_headers.clone(),
+                retries: get_retries(args),
             };
             let default_output: String = "text".to_string();
             let output_arg: &String = args.get_one::<String>("output").unwrap_or(&default_output);
@@ -136,6 +137,7 @@ pub fn run(args: &ArgMatches, raw_args: Vec<String>) -> Result<serde_json::Value
                 auth: Some(auth),
                 ssl_options: ssl_options.clone(),
                 custom_headers: custom_headers.clone(),
+                retries: get_retries(args),
             };
 
             let default_output: String = "text".to_string();
@@ -290,6 +292,7 @@ pub fn run(args: &ArgMatches, raw_args: Vec<String>) -> Result<serde_json::Value
                 auth: Some(auth),
                 ssl_options: ssl_options.clone(),
                 custom_headers: custom_headers.clone(),
+                retries: get_retries(args),
             };
             let default_output: String = "table".to_string();
             let output_arg: &String = args.get_one::<String>("output").unwrap_or(&default_output);
@@ -320,6 +323,7 @@ pub fn run(args: &ArgMatches, raw_args: Vec<String>) -> Result<serde_json::Value
                 auth: Some(auth),
                 ssl_options: ssl_options.clone(),
                 custom_headers: custom_headers.clone(),
+                retries: get_retries(args),
             };
             let default_output: String = "table".to_string();
             let output_arg: &String = args.get_one::<String>("output").unwrap_or(&default_output);

--- a/src/cli/pactflow/main/provider_contracts/publish.rs
+++ b/src/cli/pactflow/main/provider_contracts/publish.rs
@@ -9,7 +9,7 @@ use crate::cli::{
     pact_broker::main::{
         HALClient, Notice, PactBrokerError, process_notices,
         utils::{
-            get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_ssl_options,
+            get_auth, get_broker_relation, get_broker_url, get_custom_headers, get_retries, get_ssl_options,
         },
     },
     utils::{self, git_info},
@@ -106,7 +106,8 @@ pub fn publish(args: &ArgMatches) -> Result<Value, PactBrokerError> {
         Some(auth.clone()),
         ssl_options.clone(),
         custom_headers.clone(),
-    );
+    )
+    .with_retry_count(get_retries(args));
 
     // Use pf:publish-provider-contract relation
     let publish_contract_href_path = tokio::runtime::Runtime::new().unwrap().block_on(async {


### PR DESCRIPTION
Adjust the retry logic so that it:

- Retries on 5XX server errors, 429 Too Many Requests, and 408 Request
  Timeout
- In the case of a 429, also parse the `Retry-After` header (if present)
  for the delay
- Tweak the exponential retry delay from millisecond decades starting
  from 1ms, to powers of 2 starting from 0.5s. It is unlikely that a 1ms
  delay will resolve the issue, but also going from 1s to 10s to 100s
  is quite a steep increase.

Also took the opportunity to upgrade reqwest to 0.13.
