### PR TITLE
chore(ci): wire in pactflow to follow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
   pactflow:
     name: PactFlow
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test]
     runs-on: ubuntu-latest
     env:
       PACTICIPANT: pact-broker-cli
@@ -117,11 +118,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: pacts-ubuntu-latest
+          path: target/pacts
       - name: Build CLI
         run: cargo build
       - name: Publish pacts to PactFlow
         run: |
-          ./target/release/pact-broker-cli publish target/pacts \
+          ./target/debug/pact-broker-cli publish target/pacts \
             --consumer-app-version "${GITHUB_SHA}" \
             --branch "${GITHUB_REF_NAME}"
         env:
@@ -129,7 +131,7 @@ jobs:
           PACT_BROKER_TOKEN: ${{ secrets.PACTFLOW_PACT_OSS_TOKEN }}
       - name: Can I deploy?
         run: |
-          ./target/release/pact-broker-cli can-i-deploy \
+          ./target/debug/pact-broker-cli can-i-deploy \
             --pacticipant "${PACTICIPANT}" \
             --version "${GITHUB_SHA}" \
             --pacticipant "Pact Broker" \


### PR DESCRIPTION
The PactFlow tests are meant pull in artefacts from tests, but the inter-job dependency was missing. Also, a minor fix to call the debug CLI (to avoid expensive release builds).