### PR TITLE
fix(can-i-deploy): use latestby=cvpv when targeting an environment

### DIFF
--- a/src/cli/pact_broker/main/can_i_deploy.rs
+++ b/src/cli/pact_broker/main/can_i_deploy.rs
@@ -300,10 +300,14 @@ pub fn can_i_deploy(
             matrix_href_path.push_str(&format!("tag={}&", urlencoding::encode(to)));
         }
 
-        if selectors.len() == 1 {
-            matrix_href_path.push_str("latestby=cvp");
-        } else {
+        // Use "cvpv" whenever an environment is targeted so that every version of an integrated
+        // application that is currently released/deployed to the environment is evaluated
+        // independently. "cvp" collapses these down to the latest provider version, hiding
+        // incompatible versions that are still live. See pact_broker issue #903.
+        if to_environment.is_some() || selectors.len() > 1 {
             matrix_href_path.push_str("latestby=cvpv");
+        } else {
+            matrix_href_path.push_str("latestby=cvp");
         }
 
         if let Some(to_environment) = to_environment {
@@ -1036,6 +1040,171 @@ mod can_i_deploy_tests {
         let raw_args: Vec<String> = raw_args.into_iter().map(|s| s.to_string()).collect();
         let result = can_i_deploy(&matches, raw_args, false);
         assert!(result.is_ok());
+    }
+
+    // When deploying to an environment, every version of an integrated application that is
+    // currently released/deployed there must be evaluated, so "cvpv" is used (not "cvp" which
+    // would collapse to the latest provider version and hide still-live incompatible versions).
+    // See pact_broker issue #903.
+    #[test]
+    fn to_environment_uses_cvpv() {
+        let config = MockServerConfig {
+            pact_specification: PactSpecification::V2,
+            ..Default::default()
+        };
+        let pact_broker_service = PactBuilder::new("pact-broker-cli", "Pact Broker")
+            .interaction("a request for the compatibility matrix for Foo version 1.2.3 against the production environment", "", |mut i| {
+                i.given("the pact for Foo version 1.2.3 has been verified by the versions of Bar in the production environment");
+                i.request
+                    .get()
+                    .path("/matrix")
+                    .query_param("q[][pacticipant]", "Foo")
+                    .query_param("q[][version]", "1.2.3")
+                    .query_param("latestby", "cvpv")
+                    .query_param("environment", "production");
+                i.response
+                    .status(200)
+                    .header("Content-Type", "application/hal+json;charset=utf-8")
+                    .json_body(pact_broker_matrix_response_body());
+                i
+            })
+            .start_mock_server(None, Some(config));
+        let mock_server_url = pact_broker_service.url();
+
+        let raw_args = vec![
+            "can-i-deploy",
+            "-b",
+            mock_server_url.as_str(),
+            "--pacticipant",
+            "Foo",
+            "--version",
+            "1.2.3",
+            "--to-environment",
+            "production",
+        ];
+        let matches = build_matches(raw_args.clone());
+        let raw_args: Vec<String> = raw_args.into_iter().map(|s| s.to_string()).collect();
+        let result = can_i_deploy(&matches, raw_args, false);
+        assert!(result.is_ok());
+    }
+
+    // False-positive scenario from issue #903: when multiple provider versions are released to an
+    // environment and one fails, cvpv preserves the failing row. cvp would collapse it away,
+    // returning a false "deployable: true". The CLI must return Err when deployable is false.
+    #[test]
+    fn to_environment_not_deployable_when_a_released_provider_version_fails() {
+        let config = MockServerConfig {
+            pact_specification: PactSpecification::V2,
+            ..Default::default()
+        };
+        let pact_broker_service = PactBuilder::new("pact-broker-cli", "Pact Broker")
+            .interaction(
+                "a request for the compatibility matrix for Foo 1.2.3 against production where a released provider version has a failing verification",
+                "",
+                |mut i| {
+                    i.given("Bar versions 10 (failing) and 11 (passing) are both released to production");
+                    i.request
+                        .get()
+                        .path("/matrix")
+                        .query_param("q[][pacticipant]", "Foo")
+                        .query_param("q[][version]", "1.2.3")
+                        .query_param("latestby", "cvpv")
+                        .query_param("environment", "production");
+                    i.response
+                        .status(200)
+                        .header("Content-Type", "application/hal+json;charset=utf-8")
+                        .json_body(json_pattern!({
+                            "summary": { "deployable": false },
+                            "matrix": each_like!({
+                                "consumer": { "name": like!("Foo"), "version": { "number": like!("1.2.3") } },
+                                "provider": { "name": like!("Bar"), "version": { "number": like!("10") } },
+                                "verificationResult": {
+                                    "success": false,
+                                    "_links": { "self": { "href": like!("http://result") } }
+                                }
+                            }, min=1)
+                        }));
+                    i
+                },
+            )
+            .start_mock_server(None, Some(config));
+        let mock_server_url = pact_broker_service.url();
+
+        let raw_args = vec![
+            "can-i-deploy",
+            "-b",
+            mock_server_url.as_str(),
+            "--pacticipant",
+            "Foo",
+            "--version",
+            "1.2.3",
+            "--to-environment",
+            "production",
+        ];
+        let matches = build_matches(raw_args.clone());
+        let raw_args: Vec<String> = raw_args.into_iter().map(|s| s.to_string()).collect();
+        let result = can_i_deploy(&matches, raw_args, false);
+        assert!(result.is_err());
+    }
+
+    // When multiple provider versions are released/deployed to an environment and all are
+    // compatible, cvpv returns a row for each — the CLI must report deployable.
+    #[test]
+    fn to_environment_deployable_when_all_released_versions_are_compatible() {
+        let config = MockServerConfig {
+            pact_specification: PactSpecification::V2,
+            ..Default::default()
+        };
+        let pact_broker_service = PactBuilder::new("pact-broker-cli", "Pact Broker")
+            .interaction(
+                "a request for the compatibility matrix for Foo 1.2.3 against production where all released provider versions are compatible",
+                "",
+                |mut i| {
+                    i.given("Bar versions 10 and 11 are both released to production with passing verifications");
+                    i.request
+                        .get()
+                        .path("/matrix")
+                        .query_param("q[][pacticipant]", "Foo")
+                        .query_param("q[][version]", "1.2.3")
+                        .query_param("latestby", "cvpv")
+                        .query_param("environment", "production");
+                    i.response
+                        .status(200)
+                        .header("Content-Type", "application/hal+json;charset=utf-8")
+                        .json_body(json_pattern!({
+                            "summary": { "deployable": true },
+                            "matrix": each_like!({
+                                "consumer": { "name": like!("Foo"), "version": { "number": like!("1.2.3") } },
+                                "provider": { "name": like!("Bar"), "version": { "number": like!("10") } },
+                                "verificationResult": {
+                                    "success": true,
+                                    "_links": { "self": { "href": like!("http://result") } }
+                                }
+                            }, min=2)
+                        }));
+                    i
+                },
+            )
+            .start_mock_server(None, Some(config));
+        let mock_server_url = pact_broker_service.url();
+
+        let raw_args = vec![
+            "can-i-deploy",
+            "-b",
+            mock_server_url.as_str(),
+            "--pacticipant",
+            "Foo",
+            "--version",
+            "1.2.3",
+            "--to-environment",
+            "production",
+        ];
+        let matches = build_matches(raw_args.clone());
+        let raw_args: Vec<String> = raw_args.into_iter().map(|s| s.to_string()).collect();
+        let result = can_i_deploy(&matches, raw_args, false);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("Computer says yes"));
     }
 
     // sends URL Querying broker at: http://127.0.0.1:61567/matrix?q[][pacticipant]=Foo&q[][version]=1.2.3&q[][pacticipant]=Bar&q[][latest]=true&q[][tag]=prod&latestby=cvpv


### PR DESCRIPTION
[PACT-6874](https://smartbear.atlassian.net/browse/PACT-6874)

## Summary

- Fixes a false-positive in `can-i-deploy --to-environment` when multiple versions of a provider are simultaneously live in an environment (via `record-release` or multi-target `record-deployment`).
- The previous `latestby=cvp` collapsed all co-resident provider versions to the latest, silently discarding failing verifications for older still-live versions and returning a false "deployable: true".
- Switching to `latestby=cvpv` when `--to-environment` is set ensures every currently-deployed/released provider version gets its own matrix row and is evaluated independently.

Fixes pact-foundation/pact_broker#903.

## Root cause

`cvp` groups matrix rows by `(consumer, consumer_version, provider)` and keeps only the row with the highest provider version order. When two provider versions are co-resident in an environment (e.g. `v1` released for a long-running service alongside a newly released `v2`), the `v1` row — which may have a failing verification — is silently dropped. `cvpv` adds `provider_version` to the group key so each live version keeps its own row.

The `--to TAG` path is intentionally unchanged: that path sets `latest=true`, which causes the selector resolver to return a single version per provider before `latestby` is applied, making `cvp` and `cvpv` equivalent there.

## Changes

- `can_i_deploy.rs`: changed the `latestby` condition from `selectors.len() == 1` to `to_environment.is_some() || selectors.len() > 1`, so a single-selector environment query now uses `cvpv` instead of `cvp`.

## Tests

Three new unit tests added (all backed by a Pact mock server):

| Test | What it guards |
|---|---|
| `to_environment_uses_cvpv` | Verifies the correct `latestby=cvpv` + `environment=` query params are sent |
| `to_environment_not_deployable_when_a_released_provider_version_fails` | Server returns `deployable: false` (failing co-released version present) → CLI exits non-zero |
| `to_environment_deployable_when_all_released_versions_are_compatible` | Server returns `deployable: true` (all co-released versions pass) → CLI exits zero with "Computer says yes" |

All 19 tests pass.

## Test plan

- [ ] `cargo test --lib can_i_deploy_tests` — 19 passed, 0 failed
- [ ] Live validation against a PactFlow instance: two provider versions co-released to production, one failing → `can-i-deploy --to-environment production` returns non-zero (was incorrectly returning zero before this fix)
- [ ] Confirm `--to TAG` (single selector, no `--to-environment`) still sends `latestby=cvp` — covered by existing `latest_tagged_versions_of_other_services` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)