### PR TITLE
fix(legacy-artifacts): repackage Windows zip from archive root

### DIFF
--- a/.github/workflows/legacy-artifacts.yml
+++ b/.github/workflows/legacy-artifacts.yml
@@ -87,7 +87,7 @@ jobs:
 
             if [[ "$archive_ext" == "zip" ]]; then
               unzip -q "$archive"
-              cp "pact-broker-cli-${target}/pact-broker-cli.exe" "$legacy_name"
+              cp "pact-broker-cli.exe" "$legacy_name"
             else
               tar xJf "$archive"
               cp "pact-broker-cli-${target}/pact-broker-cli" "$legacy_name"


### PR DESCRIPTION
## Summary
- The v0.8.4 verification run of the new `legacy-artifacts.yml` job (added in the just-merged #TBD) failed on the Windows target: the `.zip` archive has `pact-broker-cli.exe` at its root, unlike the `.tar.xz` archives which nest under `pact-broker-cli-<target>/`.
- Fixes the `cp` source path in the zip branch to match the real archive layout, verified against the actual `pact-broker-cli-x86_64-pc-windows-msvc.zip` asset from the v0.8.4 release.

## Test plan
- [x] `actionlint .github/workflows/legacy-artifacts.yml` — clean
- [x] Verified fix against the real v0.8.4 zip asset locally
- [ ] Dispatch `legacy-artifacts.yml` from this branch (`--ref fix/legacy-artifacts-zip-path`) against v0.8.4 to confirm the fix works end-to-end before merging